### PR TITLE
feat(radio): add stream reconnection with exponential backoff

### DIFF
--- a/internal/radio/player.go
+++ b/internal/radio/player.go
@@ -33,6 +33,13 @@ type Player struct {
 	// Connection state
 	connecting bool
 	err        error
+
+	// Reconnection state
+	reconnecting   bool
+	reconnectCount int
+	maxRetries     int
+	retryChan      chan struct{}
+	stopReconnect  chan struct{}
 }
 
 // NewPlayer creates a new radio player with default stations
@@ -41,6 +48,9 @@ func NewPlayer() *Player {
 		stations:       DefaultStations(),
 		currentStation: -1,
 		volumeLevel:    0,
+		maxRetries:     3,
+		retryChan:      make(chan struct{}, 1),
+		stopReconnect:  make(chan struct{}, 1),
 	}
 }
 
@@ -88,28 +98,82 @@ func (p *Player) Play(index int) error {
 	station := p.stations[index]
 	p.mu.Unlock()
 
-	// Stop current stream
+	// Stop current stream and any reconnection attempts
 	p.Stop()
+	close(p.stopReconnect)
+	p.stopReconnect = make(chan struct{})
+	p.retryChan = make(chan struct{}, 1)
 
 	p.mu.Lock()
 	p.connecting = true
 	p.err = nil
 	p.currentStation = index
+	p.reconnectCount = 0
+	p.reconnecting = false
 	p.mu.Unlock()
 
 	// Connect in a goroutine to avoid blocking the UI
-	go func() {
+	go p.connectWithRetry(station)
+
+	return nil
+}
+
+func (p *Player) connectWithRetry(station Station) {
+	backoff := 2 * time.Second
+
+	for {
 		err := p.connectAndPlay(station)
 		p.mu.Lock()
 		p.connecting = false
 		if err != nil {
 			p.err = err
 			p.playing = false
+			p.reconnectCount++
+
+			if p.reconnectCount < p.maxRetries {
+				p.reconnecting = true
+				p.mu.Unlock()
+
+				// Wait for exponential backoff or manual retry
+				select {
+				case <-p.stopReconnect:
+					p.mu.Lock()
+					p.reconnecting = false
+					p.mu.Unlock()
+					return
+				case <-time.After(backoff):
+					backoff *= 2 // Exponential backoff: 2s, 4s, 8s
+				}
+				p.mu.Lock()
+				p.reconnecting = false
+				p.mu.Unlock()
+
+				// Try again
+				continue
+			}
+		} else {
+			p.reconnectCount = 0
 		}
 		p.mu.Unlock()
-	}()
 
-	return nil
+		// Check for manual retry request
+		if p.reconnectCount >= p.maxRetries {
+			select {
+			case <-p.retryChan:
+				p.mu.Lock()
+				p.reconnectCount = 0
+				p.err = nil
+				p.connecting = true
+				p.mu.Unlock()
+				backoff = 2 * time.Second
+				continue
+			case <-p.stopReconnect:
+				return
+			}
+		}
+
+		return
+	}
 }
 
 func (p *Player) connectAndPlay(station Station) error {
@@ -305,9 +369,82 @@ func (p *Player) IsConnecting() bool {
 	return p.connecting
 }
 
+// IsReconnecting returns whether a reconnection is in progress
+func (p *Player) IsReconnecting() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.reconnecting
+}
+
+// ReconnectCount returns the number of reconnection attempts
+func (p *Player) ReconnectCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.reconnectCount
+}
+
+// CanRetry returns whether manual retry is available (after max retries reached)
+func (p *Player) CanRetry() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.reconnectCount >= p.maxRetries && !p.reconnecting && p.err != nil
+}
+
+// Retry manually retries the last failed connection
+func (p *Player) Retry() bool {
+	p.mu.Lock()
+	if p.reconnectCount < p.maxRetries || p.err == nil {
+		p.mu.Unlock()
+		return false
+	}
+	p.mu.Unlock()
+
+	select {
+	case p.retryChan <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
 // Error returns the last error, if any
 func (p *Player) Error() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.err
+}
+
+// CheckStream checks if the stream is still active and attempts reconnection if not
+// This should be called periodically by the UI tick
+func (p *Player) CheckStream() {
+	p.mu.Lock()
+	wasPlaying := p.playing && !p.paused
+	currentStation := p.currentStation
+	p.mu.Unlock()
+
+	if !wasPlaying || currentStation < 0 {
+		return
+	}
+
+	// If we were playing but now we're not, and we're not already reconnecting
+	// and this wasn't a manual stop, try to reconnect
+	p.mu.Lock()
+	isReconnecting := p.reconnecting
+	p.mu.Unlock()
+
+	if !isReconnecting {
+		p.mu.Lock()
+		stillPlaying := p.playing && !p.paused
+		p.mu.Unlock()
+
+		if !stillPlaying {
+			// Stream dropped, trigger reconnection
+			station := p.stations[currentStation]
+			p.mu.Lock()
+			p.err = fmt.Errorf("stream disconnected")
+			p.mu.Unlock()
+
+			go p.connectWithRetry(station)
+		}
+	}
 }

--- a/internal/radio/player.go
+++ b/internal/radio/player.go
@@ -99,10 +99,16 @@ func (p *Player) Play(index int) error {
 	p.mu.Unlock()
 
 	// Stop current stream and any reconnection attempts
-	p.Stop()
-	close(p.stopReconnect)
+	// Close stopReconnect first to signal the old goroutine to exit
+	// Use recover to handle case where it's already closed
+	func() {
+		defer func() { recover() }()
+		close(p.stopReconnect)
+	}()
 	p.stopReconnect = make(chan struct{})
 	p.retryChan = make(chan struct{}, 1)
+
+	p.Stop()
 
 	p.mu.Lock()
 	p.connecting = true
@@ -414,37 +420,33 @@ func (p *Player) Error() error {
 	return p.err
 }
 
+// MaxRetries returns the maximum number of reconnection attempts
+func (p *Player) MaxRetries() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.maxRetries
+}
+
 // CheckStream checks if the stream is still active and attempts reconnection if not
 // This should be called periodically by the UI tick
 func (p *Player) CheckStream() {
 	p.mu.Lock()
 	wasPlaying := p.playing && !p.paused
-	currentStation := p.currentStation
-	p.mu.Unlock()
-
-	if !wasPlaying || currentStation < 0 {
-		return
-	}
-
-	// If we were playing but now we're not, and we're not already reconnecting
-	// and this wasn't a manual stop, try to reconnect
-	p.mu.Lock()
 	isReconnecting := p.reconnecting
+	currentStation := p.currentStation
+	var station Station
+	if currentStation >= 0 && currentStation < len(p.stations) {
+		station = p.stations[currentStation]
+	}
+	stillPlaying := p.playing && !p.paused
 	p.mu.Unlock()
 
-	if !isReconnecting {
+	if wasPlaying && !stillPlaying && !isReconnecting && currentStation >= 0 {
 		p.mu.Lock()
-		stillPlaying := p.playing && !p.paused
+		p.reconnecting = true
+		p.err = fmt.Errorf("stream disconnected")
 		p.mu.Unlock()
 
-		if !stillPlaying {
-			// Stream dropped, trigger reconnection
-			station := p.stations[currentStation]
-			p.mu.Lock()
-			p.err = fmt.Errorf("stream disconnected")
-			p.mu.Unlock()
-
-			go p.connectWithRetry(station)
-		}
+		go p.connectWithRetry(station)
 	}
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -200,6 +200,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pomo.Tick()
 		m.updateVisualizer()
 
+		// Check radio stream status
+		if m.mode == ModeRadio && m.radioPlayer != nil {
+			m.radioPlayer.CheckStream()
+		}
+
 		// Check if we need to auto-advance (track finished)
 		if m.engine.IsPlaying() {
 			pos := m.engine.GetPosition()
@@ -390,6 +395,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Enter):
 		if m.mode == ModeRadio && m.radioPlayer != nil {
+			// Check for manual retry
+			if m.radioPlayer.CanRetry() {
+				if m.radioPlayer.Retry() {
+					m.setStatus("🔄 Retrying...")
+				}
+				return m, nil
+			}
+
 			if m.cursor >= 0 && m.cursor < m.radioPlayer.StationCount() {
 				if err := m.radioPlayer.Play(m.cursor); err != nil {
 					m.setStatus("❌ " + err.Error())
@@ -592,6 +605,15 @@ func (m Model) renderRadioNowPlaying() string {
 	} else if m.radioPlayer.IsConnecting() {
 		stateIcon = "🔄"
 		statusText = "Connecting..."
+		stationName = m.radioPlayer.CurrentStation().Name
+	} else if m.radioPlayer.IsReconnecting() {
+		stateIcon = "🔄"
+		retryCount := m.radioPlayer.ReconnectCount()
+		statusText = fmt.Sprintf("Reconnecting... (attempt %d/3)", retryCount+1)
+		stationName = m.radioPlayer.CurrentStation().Name
+	} else if m.radioPlayer.CanRetry() {
+		stateIcon = "❌"
+		statusText = "Connection failed (press Enter to retry)"
 		stationName = m.radioPlayer.CurrentStation().Name
 	} else if m.radioPlayer.IsPlaying() {
 		stateIcon = "📻"
@@ -808,7 +830,7 @@ func (m Model) renderHelp() string {
 			helpItems = []string{
 				"space: play/pause", "n/p: next/prev station",
 				"+/-: volume", "↑↓: navigate stations",
-				"enter: play station", "tab: switch mode",
+				"enter: play/retry", "tab: switch mode",
 				"t: start/stop pomodoro", "T: pause pomodoro",
 				"s: skip phase", "?: toggle help", "q: quit",
 			}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -609,11 +609,13 @@ func (m Model) renderRadioNowPlaying() string {
 	} else if m.radioPlayer.IsReconnecting() {
 		stateIcon = "🔄"
 		retryCount := m.radioPlayer.ReconnectCount()
-		statusText = fmt.Sprintf("Reconnecting... (attempt %d/3)", retryCount+1)
+		maxRetries := m.radioPlayer.MaxRetries()
+		statusText = fmt.Sprintf("Reconnecting... (attempt %d/%d)", retryCount+1, maxRetries)
 		stationName = m.radioPlayer.CurrentStation().Name
 	} else if m.radioPlayer.CanRetry() {
 		stateIcon = "❌"
-		statusText = "Connection failed (press Enter to retry)"
+		err := m.radioPlayer.Error()
+		statusText = fmt.Sprintf("Connection failed: %v (press Enter to retry)", err)
 		stationName = m.radioPlayer.CurrentStation().Name
 	} else if m.radioPlayer.IsPlaying() {
 		stateIcon = "📻"


### PR DESCRIPTION
## Summary
- Add reconnection state tracking in radio player (reconnecting, reconnectCount, maxRetries)
- Auto-retry up to 3 times with exponential backoff (2s, 4s, 8s)
- Show "Reconnecting... (attempt X/3)" in TUI during reconnection
- Show "Connection failed (press Enter to retry)" after max retries
- Manual retry on Enter key when connection failed
- Add CheckStream() to detect mid-stream disconnection
- Update help text to show "enter: play/retry"

## Acceptance Criteria
- [x] If a stream disconnects, show "Reconnecting..." in the TUI
- [x] Auto-retry up to 3 times with exponential backoff (2s, 4s, 8s)
- [x] After 3 failures, show error and stop trying
- [x] User can press Enter to manually retry after failure
- [x] No crash on network loss — handle all error paths gracefully