### PR TITLE
fix(cmd): ensure music-gen uses lavfi inputs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,15 +99,15 @@ tasks:
       - >-
         ffmpeg -y -f lavfi
         -i "sine=frequency=220:duration=30"
-        -i "sine=frequency=261:duration=30"
-        -i "sine=frequency=329:duration=30"
+        -f lavfi -i "sine=frequency=261:duration=30"
+        -f lavfi -i "sine=frequency=329:duration=30"
         -filter_complex "[0][1][2]amix=inputs=3:duration=longest,lowpass=f=800,volume=0.5"
         -t 30 -b:a 128k {{.MUSIC_DIR}}/ambient-chill.mp3
       - >-
         ffmpeg -y -f lavfi
         -i "sine=frequency=261:duration=30"
-        -i "sine=frequency=329:duration=30"
-        -i "sine=frequency=392:duration=30"
+        -f lavfi -i "sine=frequency=329:duration=30"
+        -f lavfi -i "sine=frequency=392:duration=30"
         -filter_complex "[0][1][2]amix=inputs=3:duration=longest,lowpass=f=600,volume=0.4"
         -t 30 -b:a 128k {{.MUSIC_DIR}}/dreamy-focus.mp3
       - echo "Generated sample tracks in {{.MUSIC_DIR}}/"


### PR DESCRIPTION
## Summary
- Fix `task music-gen` by adding `-f lavfi` before each sine input so ffmpeg treats them as lavfi sources
- Prevents the "No such file or directory" error when generating sample tracks

## Related Issue
Closes #10

## Changes
- `Taskfile.yml` — add `-f lavfi` for the second and third inputs in both ffmpeg commands

## How to Test
1. `task music-gen`
2. Confirm `./music/ambient-chill.mp3` and `./music/dreamy-focus.mp3` are generated

## Checklist
- [x] `task check` passes (fmt + vet + test)
- [x] No hardcoded values or secrets
- [x] Code is readable and commented where needed