### PR TITLE
feat(radio): add infinite playback with auto-advance on station failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ music/*.flac
 .vscode/
 *.swp
 *.swo
+
+# Task runner
+.task/

--- a/internal/radio/player.go
+++ b/internal/radio/player.go
@@ -40,6 +40,10 @@ type Player struct {
 	maxRetries     int
 	retryChan      chan struct{}
 	stopReconnect  chan struct{}
+
+	// Auto-advance state
+	consecutiveFailures  int
+	OnStationUnavailable func(station Station)
 }
 
 // NewPlayer creates a new radio player with default stations
@@ -159,23 +163,38 @@ func (p *Player) connectWithRetry(station Station) {
 			}
 		} else {
 			p.reconnectCount = 0
+			p.consecutiveFailures = 0
 		}
 		p.mu.Unlock()
 
 		// Check for manual retry request
 		if p.reconnectCount >= p.maxRetries {
-			select {
-			case <-p.retryChan:
+			// Auto-advance: try next station
+			p.mu.Lock()
+			p.consecutiveFailures++
+			callback := p.OnStationUnavailable
+			currentIdx := p.currentStation
+			p.mu.Unlock()
+
+			if callback != nil {
+				callback(station)
+			}
+
+			// Try next station
+			nextIdx := (currentIdx + 1) % len(p.stations)
+			if p.consecutiveFailures < len(p.stations) {
 				p.mu.Lock()
 				p.reconnectCount = 0
-				p.err = nil
 				p.connecting = true
+				p.currentStation = nextIdx
 				p.mu.Unlock()
+				station = p.stations[nextIdx]
 				backoff = 2 * time.Second
 				continue
-			case <-p.stopReconnect:
-				return
 			}
+
+			// All stations failed
+			return
 		}
 
 		return
@@ -425,6 +444,13 @@ func (p *Player) MaxRetries() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.maxRetries
+}
+
+// ConsecutiveFailures returns the number of consecutive station failures
+func (p *Player) ConsecutiveFailures() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.consecutiveFailures
 }
 
 // CheckStream checks if the stream is still active and attempts reconnection if not

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -152,9 +152,13 @@ func NewModel(engine *audio.Engine, radioPlayer *radio.Player) Model {
 		vizBars:     make([]float64, 30),
 	}
 
-	// When a track ends, send a message
-	engine.OnTrackEnd = func() {
-		// This runs in the audio goroutine, need to handle carefully
+	// Track advancement uses polling in Update() tick - no callback needed
+
+	// Wire up radio auto-advance callback
+	if radioPlayer != nil {
+		radioPlayer.OnStationUnavailable = func(station radio.Station) {
+			// Status will be shown via the TUI's periodic check
+		}
 	}
 
 	return m


### PR DESCRIPTION
## Summary
- Auto-advance to next station after max reconnection retries fail
- Track consecutive failures and cycle through all stations before giving up
- Add ConsecutiveFailures() method for TUI visibility
- Clean up dead OnTrackEnd callback in local mode (using polling approach)
- Show status via existing reconnection UI states

## Related Issue
Closes #12

## Changes
- `internal/radio/player.go` — Add auto-advance logic after retry exhaustion, consecutive failure tracking
- `internal/ui/tui.go` — Wire up OnStationUnavailable callback, remove dead OnTrackEnd code

## Acceptance Criteria
- [x] Radio: After max reconnection retries fail → auto-advance to next station
- [x] Radio: Cycle through all stations before giving up entirely
- [x] Local: Clean up dead OnTrackEnd callback code
- [x] `task check` passes (fmt + vet + test)

## How to Test
1. Start radio player with a station
2. Disconnect network or use invalid station URL
3. After 3 auto-retry failures, should automatically switch to next station
4. Should cycle through all stations before stopping