### PR TITLE
fix(cmd): fallback to radio when music folder is empty

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -80,10 +81,20 @@ func main() {
 	} else {
 		if err := engine.ScanDirectory(absDir); err != nil {
 			if !startInRadio {
-				fmt.Fprintf(os.Stderr, "Error scanning music: %v\n", err)
-				fmt.Printf("Add .mp3 files to: %s\n", absDir)
-				fmt.Println("Or run with --radio to use internet stations.")
-				os.Exit(1)
+				hasMP3, scanErr := hasMP3Files(absDir)
+				if scanErr != nil {
+					fmt.Fprintf(os.Stderr, "Error scanning music: %v\n", err)
+					os.Exit(1)
+				}
+
+				if !hasMP3 {
+					fmt.Printf("No local tracks found in %s\n", absDir)
+					fmt.Println("Starting in radio mode. Use --list-stations to browse stations.")
+					startInRadio = true
+				} else {
+					fmt.Fprintf(os.Stderr, "Error scanning music: %v\n", err)
+					os.Exit(1)
+				}
 			}
 		} else {
 			fmt.Printf("📂 Found %d tracks in %s\n", engine.TrackCount(), absDir)
@@ -113,4 +124,22 @@ func main() {
 	engine.Stop()
 	radioPlayer.Stop()
 	fmt.Println("\n👋 Thanks for chilling with go-beats!")
+}
+
+func hasMP3Files(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(entry.Name()), ".mp3") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
## Summary
- Treat an empty `music/` directory the same as a missing one by falling back to radio mode.
- Keep existing behavior for valid local libraries and non-empty `.mp3` directories.

## Related Issue
Closes #13

## Changes
- `cmd/main.go` — On `ScanDirectory` failure, detect whether `.mp3` files exist in the target directory.
- `cmd/main.go` — If no `.mp3` files are present, show a friendly message and start in radio mode instead of exiting.
- `cmd/main.go` — Added `hasMP3Files()` helper for explicit empty-library detection.

## How to Test
1. `mkdir -p music && rm -f music/*.mp3`
2. `task run` → should start in radio mode with friendly fallback message.
3. `rm -rf music && task run` → should still fallback to radio mode (existing behavior).
4. Add at least one `.mp3` to `music/` and run `task run` → should load local tracks as before.
5. Run `task check`.

## Checklist
- [x] `task check` passes (fmt + vet + test)
- [x] No hardcoded values or secrets
- [x] Code is readable and commented where needed