### PR TITLE
feat(radio): add LofiRadio24 to station registry

### DIFF
--- a/internal/radio/stations.go
+++ b/internal/radio/stations.go
@@ -31,6 +31,12 @@ func DefaultStations() []Station {
 			Description: "Box Lofi - 24/7 lofi beats",
 		},
 		{
+			Name:        "LofiRadio24",
+			URL:         "https://stream.zeno.fm/0r0xa792kwzuv",
+			Genre:       "lofi hip-hop",
+			Description: "24/7 lofi hip hop radio - relaxing beats to study and chill",
+		},
+		{
 			Name:        "Nightride FM",
 			URL:         "https://stream.nightride.fm/nightride.m4a",
 			Genre:       "synthwave",

--- a/internal/radio/stations_test.go
+++ b/internal/radio/stations_test.go
@@ -93,3 +93,24 @@ func TestStationStruct(t *testing.T) {
 		t.Errorf("Description = %v, want %v", station.Description, "Test description")
 	}
 }
+
+func TestDefaultStationsIncludesLofiRadio24(t *testing.T) {
+	stations := DefaultStations()
+
+	for _, station := range stations {
+		if station.Name == "LofiRadio24" {
+			if station.URL != "https://stream.zeno.fm/0r0xa792kwzuv" {
+				t.Errorf("LofiRadio24 URL = %q, want %q", station.URL, "https://stream.zeno.fm/0r0xa792kwzuv")
+			}
+			if station.Genre != "lofi hip-hop" {
+				t.Errorf("LofiRadio24 genre = %q, want %q", station.Genre, "lofi hip-hop")
+			}
+			if station.Description != "24/7 lofi hip hop radio - relaxing beats to study and chill" {
+				t.Errorf("LofiRadio24 description = %q, want %q", station.Description, "24/7 lofi hip hop radio - relaxing beats to study and chill")
+			}
+			return
+		}
+	}
+
+	t.Fatal("LofiRadio24 station not found")
+}


### PR DESCRIPTION
## Summary
- Add LofiRadio24 as a new default radio station.
- Verify station metadata and stream URL through unit tests.

## Related Issue
Closes #18

## Changes
- `internal/radio/stations.go` — Added `LofiRadio24` station entry with name, genre, description, and URL.
- `internal/radio/stations_test.go` — Added assertion-based test to ensure `LofiRadio24` remains in defaults with expected metadata.

## How to Test
1. `task check`
2. `./go-beats --list-stations` and verify `LofiRadio24` appears in output.
3. `./go-beats --radio --station 3` (or the listed index for `LofiRadio24`) and verify stream starts.

## Checklist
- [x] `task check` passes (fmt + vet + test)
- [x] No hardcoded values or secrets
- [x] Code is readable and commented where needed