### PR TITLE
fix(radio): prevent stream timeout after connection

### DIFF
--- a/internal/radio/player.go
+++ b/internal/radio/player.go
@@ -3,6 +3,7 @@ package radio
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -204,7 +205,13 @@ func (p *Player) connectWithRetry(station Station) {
 func (p *Player) connectAndPlay(station Station) error {
 	// Create HTTP request
 	client := &http.Client{
-		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: 15 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+		},
 	}
 
 	req, err := http.NewRequest("GET", station.URL, nil)


### PR DESCRIPTION
## Summary
- Fix radio streams disconnecting after ~15 seconds by removing `http.Client.Timeout` from stream requests.
- Keep fail-fast behavior for unreachable servers using transport-level dial, TLS handshake, and response-header timeouts.

## Related Issue
Closes #21

## Changes
- `internal/radio/player.go` — Replaced global request timeout with:
  - `DialContext` timeout (15s)
  - `TLSHandshakeTimeout` (10s)
  - `ResponseHeaderTimeout` (10s)
- `internal/radio/player.go` — Kept continuous response-body reading unbounded for live MP3 streams.

## How to Test
1. `task check`
2. `./go-beats --radio --station 3` (LofiRadio24)
3. Let it run for >2 minutes and confirm playback is uninterrupted.
4. Test unreachable endpoint scenario (optional) and confirm initial connect still fails quickly.

## Checklist
- [x] `task check` passes (fmt + vet + test)
- [x] No hardcoded values or secrets
- [x] Code is readable and commented where needed